### PR TITLE
feat: added scaling options

### DIFF
--- a/.changes/unreleased/Added-20250724-092055.yaml
+++ b/.changes/unreleased/Added-20250724-092055.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added support for scaling based on cpu and memory, as well as changing http request scaling rules
+time: 2025-07-24T09:20:55.519865+02:00

--- a/README.md
+++ b/README.md
@@ -30,17 +30,22 @@ No modules.
 | <a name="input_container_app_environment_id"></a> [container\_app\_environment\_id](#input\_container\_app\_environment\_id) | The container app environment to be used for the container | `string` | n/a | yes |
 | <a name="input_container_port"></a> [container\_port](#input\_container\_port) | The port the container listens on | `number` | `4000` | no |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | The CPU to be used for the container | `number` | `0.25` | no |
+| <a name="input_cpu_scale_rule"></a> [cpu\_scale\_rule](#input\_cpu\_scale\_rule) | CPU scale rules to be set on the container | <pre>object({<br/>    threshold = optional(number, 50)<br/>    type = optional(string, "Utilization")<br/>  })</pre> | `null` | no |
 | <a name="input_env_vars"></a> [env\_vars](#input\_env\_vars) | Environment variables to be set in the container | `map(string)` | `{}` | no |
 | <a name="input_external_enabled"></a> [external\_enabled](#input\_external\_enabled) | Whether to enable external access | `bool` | `false` | no |
 | <a name="input_healthcheck"></a> [healthcheck](#input\_healthcheck) | Healthcheck configuration | <pre>object({<br/>    path                = string<br/>    unhealthy_threshold = number<br/>    timeout             = number<br/>    interval            = number<br/>  })</pre> | <pre>{<br/>  "interval": 5,<br/>  "path": "/",<br/>  "timeout": 2,<br/>  "unhealthy_threshold": 3<br/>}</pre> | no |
-| <a name="input_identity_id"></a> [identity\_id](#input\_identity\_id) | The identity to be used for the container | `string` | n/a | yes |
+| <a name="input_http_scale_rule"></a> [http\_scale\_rule](#input\_http\_scale\_rule) | HTTP scale rules to be set on the container | <pre>object({<br/>    concurrent_requests = optional(number, 100)<br/>  })</pre> | n/a | yes |
+| <a name="input_identity_id"></a> [identity\_id](#input\_identity\_id) | The identity to be used for the container registry | `string` | n/a | yes |
 | <a name="input_image"></a> [image](#input\_image) | The image to be used for the container | `string` | n/a | yes |
 | <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id) | The key vault to be used for the container | `string` | `null` | no |
 | <a name="input_max_replicas"></a> [max\_replicas](#input\_max\_replicas) | The maximum number of instances to run | `number` | `1` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | The memory to be used for the container | `string` | `"0.5Gi"` | no |
+| <a name="input_memory_scale_rule"></a> [memory\_scale\_rule](#input\_memory\_scale\_rule) | Memory scale rules to be set on the container | <pre>object({<br/>    threshold = optional(number, 75)<br/>    type = optional(string, "Utilization")<br/>  })</pre> | `null` | no |
 | <a name="input_min_replicas"></a> [min\_replicas](#input\_min\_replicas) | The minimum number of instances to run | `number` | `0` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the container | `string` | n/a | yes |
 | <a name="input_proxy_image"></a> [proxy\_image](#input\_proxy\_image) | Version of the reverse proxy to deploy | `string` | `""` | no |
+| <a name="input_registry_password"></a> [registry\_password](#input\_registry\_password) | The name of the secret to be used for the container registry password | `string` | `""` | no |
+| <a name="input_registry_username"></a> [registry\_username](#input\_registry\_username) | The username to be used for the container registry | `string` | `""` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The resource group to be used for the container | `string` | n/a | yes |
 | <a name="input_secrets"></a> [secrets](#input\_secrets) | n/a | <pre>list(object({<br/>    secret_id   = string<br/>    secret_name = string<br/>    env_name    = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be set on the container | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,40 @@ resource "azurerm_container_app" "this" {
     min_replicas = var.min_replicas
     max_replicas = var.max_replicas
 
+
+    dynamic "http_scale_rule" {
+      for_each = var.http_scale_rule != null ? [var.http_scale_rule] : []
+      content {
+        name                = "http-scaler"
+        concurrent_requests = var.http_scale_rule.concurrent_requests
+      }
+    }
+
+    dynamic "custom_scale_rule" {
+      for_each = var.cpu_scale_rule != null ? [var.cpu_scale_rule] : []
+      content {
+        custom_rule_type = "cpu"
+        metadata = {
+          "type" : var.cpu_scale_rule.type,
+          "value" : var.cpu_scale_rule.threshold
+        }
+        name = "cpu-scaler"
+      }
+    }
+
+
+    dynamic "custom_scale_rule" {
+      for_each = var.memory_scale_rule != null ? [var.memory_scale_rule] : []
+      content {
+        custom_rule_type = "memory"
+        metadata = {
+          "type" : var.memory_scale_rule.type,
+          "value" : var.memory_scale_rule.threshold
+        }
+        name = "memory-scaler"
+      }
+    }
+
     container {
       name   = "main"
       image  = var.image

--- a/variables.tf
+++ b/variables.tf
@@ -132,3 +132,42 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "http_scale_rule" {
+  description = "HTTP scale rules to be set on the container"
+  type = object({
+    concurrent_requests = number
+  })
+  nullable = true
+  default = {
+    concurrent_requests = 50
+  }
+}
+
+
+variable "cpu_scale_rule" {
+  description = "CPU scale rules to be set on the container"
+  type = object({
+    threshold = number
+    type      = string
+  })
+  nullable = true
+  default = {
+    threshold = 50
+    type      = "Utilization"
+  }
+}
+
+variable "memory_scale_rule" {
+  description = "Memory scale rules to be set on the container"
+  type = object({
+    threshold = number
+    type      = string
+  })
+  nullable = true
+  default = {
+    threshold = 75
+    type      = "Utilization"
+  }
+}
+


### PR DESCRIPTION
This pull request introduces support for scaling container apps based on CPU, memory, and HTTP request rules. It also includes updates to the Terraform module to support these scaling configurations, along with enhancements for container registry authentication.

### Scaling Features:
* Added variables `http_scale_rule`, `cpu_scale_rule`, and `memory_scale_rule` in `variables.tf` to define scaling rules for HTTP requests, CPU utilization, and memory utilization, respectively.
* Updated `main.tf` to include `http_scale_rule`, `cpu_scale_rule`, and `memory_scale_rule` blocks for configuring scaling behavior in the `azurerm_container_app` resource.

### Documentation Updates:
* Updated `README.md` to include descriptions and details for the new input variables: `http_scale_rule`, `cpu_scale_rule`, and `memory_scale_rule`.

### Change Log:
* Added a changelog entry in `.changes/unreleased/Added-20250724-092055.yaml` to document the new scaling features.

### Container Registry Enhancements:
* Added new input variables `registry_username` and `registry_password` in `README.md` for container registry authentication.