### PR TITLE
feat(proxy sidecar): allow setting env and secret on proxy sidecar

### DIFF
--- a/.changes/unreleased/Added-20260421-175021.yaml
+++ b/.changes/unreleased/Added-20260421-175021.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: allow setting env and secrets on proxy image
+time: 2026-04-21T17:50:21.515727+02:00

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ No modules.
 | <a name="input_min_replicas"></a> [min\_replicas](#input\_min\_replicas) | The minimum number of instances to run | `number` | `0` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the container | `string` | n/a | yes |
 | <a name="input_proxy_image"></a> [proxy\_image](#input\_proxy\_image) | Version of the reverse proxy to deploy | `string` | `""` | no |
+| <a name="input_proxy_env_vars"></a> [proxy\_env\_vars](#input\_proxy\_env\_vars) | Environment variables to be set on the reverse proxy container | `map(string)` | `{}` | no |
+| <a name="input_proxy_secrets"></a> [proxy\_secrets](#input\_proxy\_secrets) | Secrets to be exposed on the reverse proxy container | <pre>list(object({<br/>    secret_id   = string<br/>    secret_name = string<br/>    env_name    = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_registry_password"></a> [registry\_password](#input\_registry\_password) | The name of the secret to be used for the container registry password | `string` | `""` | no |
 | <a name="input_registry_username"></a> [registry\_username](#input\_registry\_username) | The username to be used for the container registry | `string` | `""` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The resource group to be used for the container | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,9 @@
+locals {
+  container_secrets = {
+    for secret in concat(var.secrets, var.proxy_secrets) : secret.secret_name => secret
+  }
+}
+
 resource "azurerm_container_app" "this" {
   name                         = var.name
   container_app_environment_id = var.container_app_environment_id
@@ -232,13 +238,31 @@ resource "azurerm_container_app" "this" {
             initial_delay           = var.healthcheck_startup.initial_delay
           }
         }
+
+        dynamic "env" {
+          for_each = var.proxy_env_vars
+
+          content {
+            name  = env.key
+            value = env.value
+          }
+        }
+
+        dynamic "env" {
+          for_each = var.proxy_secrets
+
+          content {
+            name        = env.value.env_name
+            secret_name = env.value.secret_name
+          }
+        }
       }
     }
 
   }
 
   dynamic "secret" {
-    for_each = var.secrets
+    for_each = local.container_secrets
 
     content {
       identity            = var.identity_id
@@ -284,4 +308,3 @@ resource "azurerm_container_app" "this" {
     }
   }
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,22 @@ variable "proxy_image" {
   description = "Version of the reverse proxy to deploy"
 }
 
+variable "proxy_env_vars" {
+  description = "Environment variables to be set on the reverse proxy container"
+  type        = map(string)
+  default     = {}
+}
+
+variable "proxy_secrets" {
+  description = "Secrets to be exposed on the reverse proxy container"
+  type = list(object({
+    secret_id   = string
+    secret_name = string
+    env_name    = string
+  }))
+  default = []
+}
+
 variable "identity_id" {
   description = "The identity to be used for the container registry"
   type        = string


### PR DESCRIPTION
Have a use case where we need to set some env and secrets on Caddy to enable OpenTelemetry tracing/dynamic configuration with env vars