### PR TITLE
fix: revert unsupported healthy_threshold on liveness/startup probes

### DIFF
--- a/.changes/unreleased/revert-unsupported-probe-healthy-threshold.md
+++ b/.changes/unreleased/revert-unsupported-probe-healthy-threshold.md
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Revert unsupported healthy_threshold on liveness and startup probes
+time: 2026-04-22T12:55:44.535498+02:00

--- a/main.tf
+++ b/main.tf
@@ -81,7 +81,6 @@ resource "azurerm_container_app" "this" {
         content {
           path                    = var.healthcheck_liveness.path # Checks for status code 200 - 399
           port                    = var.container_port
-          success_count_threshold = var.healthcheck_liveness.healthy_threshold
           failure_count_threshold = var.healthcheck_liveness.unhealthy_threshold
           interval_seconds        = var.healthcheck_liveness.interval
           timeout                 = var.healthcheck_liveness.timeout
@@ -95,7 +94,6 @@ resource "azurerm_container_app" "this" {
         content {
           port                    = var.container_port
           path                    = var.healthcheck_startup.path # Checks for status code 200 - 399
-          success_count_threshold = var.healthcheck_startup.healthy_threshold
           failure_count_threshold = var.healthcheck_startup.unhealthy_threshold
           interval_seconds        = var.healthcheck_startup.interval
           timeout                 = var.healthcheck_startup.timeout

--- a/variables.tf
+++ b/variables.tf
@@ -144,7 +144,6 @@ variable "healthcheck_liveness" {
   type = object({
     path                = string
     unhealthy_threshold = optional(number, 3)
-    healthy_threshold   = optional(number, 1)
     timeout             = optional(number, 2)
     interval            = optional(number, 10)
     initial_delay       = optional(number, 30)
@@ -158,7 +157,6 @@ variable "healthcheck_startup" {
   type = object({
     path                = string
     unhealthy_threshold = optional(number, 30)
-    healthy_threshold   = optional(number, 1)
     timeout             = optional(number, 2)
     interval            = optional(number, 10)
     initial_delay       = optional(number, 0)


### PR DESCRIPTION
## Summary
- revert the 0.3.2 liveness/startup probe changes that added unsupported `healthy_threshold` input wiring
- keep `success_count_threshold` only on `readiness_probe`, matching the provider schema already used for sidecars
- add an unreleased changie fragment for the revert

## References
- Introduced in 0.3.2: https://github.com/evolve-platform/terraform-azurerm-app-container/commit/4f78774b2180039d2b6513fb3cb2f287719245c1
- 0.3.2 release failed: https://github.com/evolve-platform/terraform-azurerm-app-container/actions/runs/19703117467/job/56444017693
- Provider docs: https://registry.terraform.io/providers/hashicorp/azurerm/4.69.0/docs/resources/container_app

## Validation
- terraform fmt -check
- git diff --check
